### PR TITLE
clear .godot cache each run to ensure changes in generated glb are processed

### DIFF
--- a/gd_make_lib.sh
+++ b/gd_make_lib.sh
@@ -10,6 +10,8 @@ ANIMATIONS_DIR=${2}
 BASE_NAME=$(basename "$2")
 OUTPUT_FILE=${3:-$BASE_NAME}
 
+rm -rf $DIR/gd-proj-template/.godot
+
 "$DIR/mixamo_to_glb.sh" "$CHARACTER_FILE" "$ANIMATIONS_DIR" "$DIR/gd-proj-template/anims.glb"
 
 "$DIR/gd_gltf_to_res.sh" "$OUTPUT_FILE"


### PR DESCRIPTION
I was pulling my hair trying to figure out why after renaming the fbx files to have "-loop" as a filename suffix they still weren't looping in Godot. Even though loading the glb up in blender I could see the animation names were being updated. 

Only after deleting the .godot cache folder did it finally reprocess the glb.

Probably something Godot needs to fix but for now this was the path of least resistance.